### PR TITLE
Multiple code improvements - squid:S1066, squid:UselessParenthesesCheck, squid:S1481

### DIFF
--- a/src/main/java/org/sqsh/analyzers/ANSIAnalyzer.java
+++ b/src/main/java/org/sqsh/analyzers/ANSIAnalyzer.java
@@ -53,8 +53,8 @@ public class ANSIAnalyzer
             token = tokenizer.next();
         }
         
-        return (prevToken != null 
+        return prevToken != null
                     && prevToken.length() == 1 
-                    && prevToken.charAt(0) == terminator);
+                    && prevToken.charAt(0) == terminator;
     }
 }

--- a/src/main/java/org/sqsh/analyzers/PLSQLAnalyzer.java
+++ b/src/main/java/org/sqsh/analyzers/PLSQLAnalyzer.java
@@ -158,12 +158,9 @@ public class PLSQLAnalyzer
                         ++blockNestCount;
                     }
                 }
-                else if ("END".equals(token)) {
-                    
-                    if (isEndBlock(tokenizer)) {
-                        
-                        --blockNestCount;
-                    }
+                else if ("END".equals(token) && isEndBlock(tokenizer)) {
+
+                    --blockNestCount;
                 }
             }
             
@@ -216,12 +213,9 @@ public class PLSQLAnalyzer
         String tok = tokenizer.next();
         while (tok != null) {
             
-            if ("BEGIN".equals(tok)) {
+            if ("BEGIN".equals(tok) && isBeginBlock(tokenizer)) {
                 
-                if (isBeginBlock(tokenizer)) {
-                    
-                    return true;
-                }
+                return true;
             }
             
             tok = tokenizer.next();

--- a/src/main/java/org/sqsh/analyzers/TSQLAnalyzer.java
+++ b/src/main/java/org/sqsh/analyzers/TSQLAnalyzer.java
@@ -44,8 +44,7 @@ public class TSQLAnalyzer
         
         String prevToken = null;
         String token = tokenizer.next();
-        int blockCount = 0;
-        
+
         while (token != null) {
             
             /*
@@ -61,22 +60,14 @@ public class TSQLAnalyzer
                     
                     tokenizer.unget(nextToken);
                 }
-                else {
-                    
-                    ++blockCount;
-                }
             }
-            else if ("END".equals(token)) {
-                
-                --blockCount;
-            }
-            
+
             prevToken = token;
             token = tokenizer.next();
         }
         
-        return (prevToken != null 
+        return prevToken != null
                     && prevToken.length() == 1 
-                    && prevToken.charAt(0) == terminator);
+                    && prevToken.charAt(0) == terminator;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1066 - Collapsible "if" statements should be merged.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1481 - Unused local variables should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
George Kankava
