### PR TITLE
Multiple code improvements - squid:S1197, squid:S1155, squid:S1125, squid:S1118

### DIFF
--- a/src/main/java/org/sqsh/util/CSVReader.java
+++ b/src/main/java/org/sqsh/util/CSVReader.java
@@ -148,12 +148,12 @@ public class CSVReader {
             }
         }
         
-        if (done == false && (words.size() > 0 || word.length() > 0)) {
+        if (!done && (!words.isEmpty() || word.length() > 0)) {
             
             words.add(trimField(word));
         }
         
-        if (ch == -1 && words.size() == 0) {
+        if (ch == -1 && words.isEmpty()) {
             
             return null;
         }

--- a/src/main/java/org/sqsh/util/TimeUtils.java
+++ b/src/main/java/org/sqsh/util/TimeUtils.java
@@ -19,7 +19,9 @@ package org.sqsh.util;
  * General purpose utilities for working with time.
  */
 public class TimeUtils {
-    
+
+    private TimeUtils() {}
+
     /**
      * Given a number of milliseconds, product a string of the format
      * <pre>
@@ -138,7 +140,7 @@ public class TimeUtils {
         return sb;
     }
     
-    public static void main (String argv[]) {
+    public static void main (String[] argv) {
     	
     	System.out.println(millisToDurationString(Long.parseLong(argv[0])));
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1125 - Literal boolean values should not be used in condition expressions.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava