### PR TITLE
Multiple code improvements - squid:S1125, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/org/sqsh/renderers/AbstractPrettyRenderer.java
+++ b/src/main/java/org/sqsh/renderers/AbstractPrettyRenderer.java
@@ -55,7 +55,7 @@ public abstract class AbstractPrettyRenderer
         /*
          * Just abort if we aren't supposed to be showing headers.
          */
-        if (manager.isShowHeaders() == false) {
+        if (!manager.isShowHeaders()) {
             
             printHorizontalLine();
             return;

--- a/src/main/java/org/sqsh/renderers/CSVRenderer.java
+++ b/src/main/java/org/sqsh/renderers/CSVRenderer.java
@@ -129,7 +129,7 @@ public class CSVRenderer
         }
         
         session.out.println(line);
-        return (session.out.checkError() == false);
+        return !session.out.checkError();
     }
     
     @Override

--- a/src/main/java/org/sqsh/renderers/GraphicalTreeRenderer.java
+++ b/src/main/java/org/sqsh/renderers/GraphicalTreeRenderer.java
@@ -340,7 +340,7 @@ public class GraphicalTreeRenderer
          */
         public boolean isLeaf(){
             
-            return (force ? false : super.isLeaf());           
+            return force ? false : super.isLeaf();
             
         }
         

--- a/src/main/java/org/sqsh/renderers/InsertRenderer.java
+++ b/src/main/java/org/sqsh/renderers/InsertRenderer.java
@@ -255,7 +255,7 @@ public class InsertRenderer
         if (conn == null) {
             
             session.out.println(str);
-            return (session.out.checkError() == false);
+            return !session.out.checkError();
         }
         
         /*


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1125 - Literal boolean values should not be used in condition expressions. 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava