### PR TITLE
Multiple code improvements - squid:S1125, squid:UselessParenthesesCheck, squid:S2225

### DIFF
--- a/src/main/java/org/sqsh/variables/DimensionVariable.java
+++ b/src/main/java/org/sqsh/variables/DimensionVariable.java
@@ -76,7 +76,7 @@ public class DimensionVariable
     @Override
     public String toString () {
 
-        return (width + "x" + height);
+        return width + "x" + height;
     }
 
     

--- a/src/main/java/org/sqsh/variables/PropertyVariable.java
+++ b/src/main/java/org/sqsh/variables/PropertyVariable.java
@@ -106,7 +106,7 @@ public class PropertyVariable
         
         Throwable failure = null;
         
-        if (settable == false) {
+        if (!settable) {
             
             throw new CannotSetValueError("The value of \"" 
                 + getName() + "\" is read only");
@@ -151,16 +151,16 @@ public class PropertyVariable
             
             if (val == null) {
                 
-                return null;
+                return "";
             }
             
             return val.toString();
         }
         catch (Throwable e) {
             
-            if (quiet == true) {
+            if (quiet) {
                 
-                return null;
+                return "";
             }
             
             return "Cannot read variable '" + getName() + "': " 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1125 - Literal boolean values should not be used in condition expressions.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S2225 - "toString()" and "clone()" methods should not return null.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2225
Please let me know if you have any questions.
George Kankava